### PR TITLE
Removendo pontos e espaços do início e fim da string do cep

### DIFF
--- a/lib/sanitize-cep.js
+++ b/lib/sanitize-cep.js
@@ -30,6 +30,6 @@ function isLengthOk (cep) {
 }
 
 function sanitizeCepString (cep) {
-  return cep.trim().replace(/\./g,'').replace(/-/g,'');
+  return cep.trim().replace(/\.|-/g,'')
 }
 

--- a/lib/sanitize-cep.js
+++ b/lib/sanitize-cep.js
@@ -5,7 +5,7 @@ module.exports = function (cep) {
         if (isLengthOk(cep)) return cep
       }
   } else if (typeof(cep) === 'string') {
-      cep = removeDashIfAny(cep)
+      cep = sanitizeCepString(cep)
       if (isDigitOnly(cep) && isLengthOk(cep)) return cep
   }
   return null
@@ -29,8 +29,7 @@ function isLengthOk (cep) {
   return cep.length === 8
 }
 
-function removeDashIfAny (cep) {
-  if (cep && cep[5] === '-' && cep.length === 9) return cep.slice(0, 5) + cep.slice(6)
-  else return cep
+function sanitizeCepString (cep) {
+  return cep.trim().replace(/\./g,'').replace(/-/g,'');
 }
 

--- a/test/sanitize-cep.js
+++ b/test/sanitize-cep.js
@@ -33,3 +33,11 @@ it('should sanitize null        to null', function () {
   assert.equal(sanitizeCep(null), null)
 })
 
+it('should sanitize \'30.130-010\' to \'30130010\'', function () {
+  assert.equal(sanitizeCep('30.130-010'), '30130010')
+})
+
+it('should sanitize \' 30130-010 \' to \'30130010\'', function () {
+  assert.equal(sanitizeCep(' 30130-010'), '30130010')
+});
+


### PR DESCRIPTION
É hábito comum escrever o CEP usando um ponto após os dois primeiros números, no formato "30.130-010". Alterei este módulo de forma a remover o ponto também, além do traço, que já era removido.
Aproveitei para remover os espaços antes e depois da string (trim).